### PR TITLE
feat: 完成新版 UI 重构与交互落地

### DIFF
--- a/app/src/main/java/com/aitidi/zzztracker/ui/TrackerApp.kt
+++ b/app/src/main/java/com/aitidi/zzztracker/ui/TrackerApp.kt
@@ -137,7 +137,7 @@ fun TrackerApp(vm: TrackerViewModel = viewModel()) {
             when (ui.sortMode) {
                 SortMode.VERSION_DESC -> filtered.sortedWith(compareByDescending<AchievementItem> { it.version }.thenBy { it.name })
                 SortMode.VERSION_ASC -> filtered.sortedWith(compareBy<AchievementItem> { it.version }.thenBy { it.name })
-                SortMode.STATUS -> filtered.sortedWith(compareBy<AchievementItem> { it.progress }.thenByDescending { it.version }.thenBy { it.name })
+                SortMode.TODO_FIRST -> filtered.sortedWith(compareBy<AchievementItem> { it.progress }.thenByDescending { it.version }.thenBy { it.name })
                 SortMode.NAME -> filtered.sortedBy { it.name }
             }
         }

--- a/app/src/main/java/com/aitidi/zzztracker/viewmodel/TrackerViewModel.kt
+++ b/app/src/main/java/com/aitidi/zzztracker/viewmodel/TrackerViewModel.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 enum class SortMode(val label: String) {
     VERSION_DESC("版本：新 → 旧"),
     VERSION_ASC("版本：旧 → 新"),
-    STATUS("完成状态"),
+    TODO_FIRST("未完成优先"),
     NAME("名称")
 }
 
@@ -125,8 +125,11 @@ class TrackerViewModel(app: Application) : AndroidViewModel(app) {
     private fun loadUiState(): TrackerUiState {
         val theme = runCatching { ThemeMode.valueOf(prefs.getString("themeMode", ThemeMode.SYSTEM.name)!!) }
             .getOrDefault(ThemeMode.SYSTEM)
-        val sort = runCatching { SortMode.valueOf(prefs.getString("sortMode", SortMode.VERSION_DESC.name)!!) }
-            .getOrDefault(SortMode.VERSION_DESC)
+        val rawSort = prefs.getString("sortMode", SortMode.VERSION_DESC.name) ?: SortMode.VERSION_DESC.name
+        val sort = when (rawSort) {
+            "STATUS" -> SortMode.TODO_FIRST // migration from old enum
+            else -> runCatching { SortMode.valueOf(rawSort) }.getOrDefault(SortMode.VERSION_DESC)
+        }
         return TrackerUiState(
             onlyTodo = prefs.getBoolean("onlyTodo", true),
             query = prefs.getString("query", "") ?: "",

--- a/ui-prototype/index.html
+++ b/ui-prototype/index.html
@@ -61,6 +61,8 @@
     .modal { width: 390px; background: #242424; border-radius: 18px 18px 0 0; border: 1px solid #3a3a3a; padding: 14px; }
     .opt { width: 100%; text-align:left; margin-top: 8px; height: 38px; border-radius: 10px; border: 1px solid var(--border); background: #2a2a2a; color: var(--text); cursor:pointer; }
     .opt.active { border-color: var(--primary); background: #32295a; }
+    .opt-row { display:flex; flex-wrap: wrap; gap:8px; }
+    .opt-row .opt { width: auto; margin-top: 0; padding: 0 12px; }
   </style>
 </head>
 <body>
@@ -126,9 +128,9 @@
     <div class="modal">
       <h3 style="margin:0 0 6px;">筛选</h3>
       <p style="margin:8px 0 4px;color:var(--muted);font-size:13px;">版本</p>
-      <div id="filterVersionOptions"></div>
+      <div id="filterVersionOptions" class="opt-row"></div>
       <p style="margin:12px 0 4px;color:var(--muted);font-size:13px;">分类</p>
-      <div id="filterCategoryOptions"></div>
+      <div id="filterCategoryOptions" class="opt-row"></div>
       <button id="filterClear" class="opt">清除全部筛选</button>
     </div>
   </div>

--- a/ui-prototype/index.html
+++ b/ui-prototype/index.html
@@ -42,9 +42,14 @@
     .icon-btn.active { background: #2f3140; border-color: var(--primary-soft); }
     .list { margin-top: 12px; display: grid; gap: 10px; }
     .item { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 12px; display:flex; justify-content: space-between; align-items: center; }
+    .item.done { opacity: .72; }
+    .item.done h4 { text-decoration: line-through; }
     .item h4 { margin: 0; font-size: 16px; }
     .item p { margin: 4px 0 0; color: var(--muted); font-size: 13px; }
+    .right-pack { display:flex; align-items:center; gap:8px; }
     .badge { font-size: 12px; color: #111; background: var(--accent); border-radius: 999px; padding: 4px 8px; }
+    .done-btn { width: 24px; height: 24px; border-radius: 7px; border:1px solid var(--border); background:#2b2b2b; color: var(--text); cursor:pointer; }
+    .item.done .done-btn { background: #3a315f; border-color: var(--primary-soft); }
     .bottom-nav { position: absolute; left: 12px; right: 12px; bottom: 14px; height: 58px; border-radius: 16px; border: 1px solid var(--border); background: #242424; display: grid; grid-template-columns: repeat(3,1fr); overflow: hidden; }
     .nav-btn { border: 0; background: transparent; color: var(--muted); font-size: 13px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap: 4px; cursor:pointer; }
     .nav-btn.active { color: var(--text); background: #2b2b2b; }
@@ -118,20 +123,30 @@
 
   <script>
     const data = [
-      ['今天也要打卡', '每日任务完成 1 次', '2.0'],
-      ['喧响测试员', '完成一次高危副本', '1.9'],
-      ['完美闪避大师', '10 次极限闪避', '2.0'],
-      ['预算控制', '累计获取 100000 丁尼', '1.8'],
-      ['收藏家', '解锁 20 条图鉴', '1.7'],
+      { title:'今天也要打卡', desc:'每日任务完成 1 次', ver:'2.0', done:false },
+      { title:'喧响测试员', desc:'完成一次高危副本', ver:'1.9', done:false },
+      { title:'完美闪避大师', desc:'10 次极限闪避', ver:'2.0', done:true },
+      { title:'预算控制', desc:'累计获取 100000 丁尼', ver:'1.8', done:false },
+      { title:'收藏家', desc:'解锁 20 条图鉴', ver:'1.7', done:true },
     ];
     const list = document.getElementById('list');
-    data.forEach(([t,d,v], i) => {
-      const done = i % 2 === 0;
-      const el = document.createElement('div');
-      el.className = 'item';
-      el.innerHTML = `<div><h4>${t}</h4><p>${d}</p></div><span class="badge">v${v}</span>`;
-      list.appendChild(el);
-    });
+
+    function renderList() {
+      list.innerHTML = '';
+      data.forEach((it, idx) => {
+        const el = document.createElement('div');
+        el.className = `item ${it.done ? 'done' : ''}`;
+        el.innerHTML = `
+          <div><h4>${it.title}</h4><p>${it.desc}</p></div>
+          <div class="right-pack">
+            <span class="badge">v${it.ver}</span>
+            <button class="done-btn" data-idx="${idx}" title="标记完成">${it.done ? '✓' : ''}</button>
+          </div>`;
+        list.appendChild(el);
+      });
+    }
+
+    renderList();
 
     const sortBtn = document.getElementById('sortBtn');
     const filterBtn = document.getElementById('filterBtn');
@@ -168,6 +183,14 @@
         document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
         document.getElementById(`screen-${key}`).classList.add('active');
       };
+    });
+
+    list.addEventListener('click', (e) => {
+      const btn = e.target.closest('.done-btn');
+      if (!btn) return;
+      const idx = Number(btn.dataset.idx);
+      data[idx].done = !data[idx].done;
+      renderList();
     });
   </script>
 </body>

--- a/ui-prototype/index.html
+++ b/ui-prototype/index.html
@@ -26,6 +26,8 @@
     }
     .phone { width: 390px; min-height: 844px; background: var(--bg); border-radius: 28px; border: 1px solid #2a2a2a; padding: 18px 14px 88px; position: relative; }
     .title { font-size: 28px; font-weight: 800; margin: 6px 6px 12px; }
+    .screen { display: none; }
+    .screen.active { display: block; }
     .summary { background: linear-gradient(135deg, #2a2a2a, #262626); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 14px; }
     .summary strong { font-size: 24px; }
     .progress { height: 8px; border-radius: 999px; background: #333; margin-top: 10px; overflow: hidden; }
@@ -55,28 +57,52 @@
 </head>
 <body>
   <div class="phone">
-    <div class="title">成就</div>
-    <div class="summary">
-      <div>总进度 <strong>142/378</strong></div>
-      <div class="progress"><div class="bar"></div></div>
-    </div>
-    <div class="search"><input placeholder="搜索成就 / 输入关键词" /></div>
-    <div class="row">
-      <div class="left">
-        <button id="todoBtn" class="chip active">仅未完成</button>
-        <button id="filterBtn" class="icon-btn">⚲</button>
-        <button id="sortBtn" class="icon-btn">↕</button>
+    <section id="screen-achievement" class="screen active">
+      <div class="title">成就</div>
+      <div class="summary">
+        <div>总进度 <strong>142/378</strong></div>
+        <div class="progress"><div class="bar"></div></div>
       </div>
-      <button id="lockBtn" class="icon-btn" aria-label="锁定">
-        <svg id="lockIcon" class="icon-flat" viewBox="0 0 24 24"><path d="M7 10V7a5 5 0 0 1 10 0v3"/><rect x="5" y="10" width="14" height="10" rx="2"/></svg>
-      </button>
-    </div>
-    <div class="list" id="list"></div>
+      <div class="search"><input placeholder="搜索成就 / 输入关键词" /></div>
+      <div class="row">
+        <div class="left">
+          <button id="todoBtn" class="chip active">仅未完成</button>
+          <button id="filterBtn" class="icon-btn" aria-label="筛选">
+            <svg class="icon-flat" viewBox="0 0 24 24"><path d="M4 6h16"/><path d="M7 12h10"/><path d="M10 18h4"/></svg>
+          </button>
+          <button id="sortBtn" class="icon-btn" aria-label="排序">
+            <svg class="icon-flat" viewBox="0 0 24 24"><path d="M8 6v12"/><path d="M5 9l3-3 3 3"/><path d="M16 18V6"/><path d="M13 15l3 3 3-3"/></svg>
+          </button>
+        </div>
+        <button id="lockBtn" class="icon-btn" aria-label="锁定">
+          <svg id="lockIcon" class="icon-flat" viewBox="0 0 24 24"><path d="M7 10V7a5 5 0 0 1 10 0v3"/><rect x="5" y="10" width="14" height="10" rx="2"/></svg>
+        </button>
+      </div>
+      <div class="list" id="list"></div>
+    </section>
+
+    <section id="screen-stats" class="screen">
+      <div class="title">统计</div>
+      <div class="summary"><div>总完成率 <strong>37.6%</strong></div><div class="progress"><div class="bar"></div></div></div>
+      <div class="list">
+        <div class="item"><div><h4>2.0 版本</h4><p>完成 31 / 82</p></div><span class="badge">37%</span></div>
+        <div class="item"><div><h4>战斗类</h4><p>完成 48 / 130</p></div><span class="badge">36%</span></div>
+      </div>
+    </section>
+
+    <section id="screen-settings" class="screen">
+      <div class="title">设置</div>
+      <div class="list">
+        <div class="item"><div><h4>主题模式</h4><p>深色</p></div></div>
+        <div class="item"><div><h4>紧凑模式</h4><p>已启用</p></div></div>
+        <div class="item"><div><h4>导出进度</h4><p>JSON</p></div></div>
+      </div>
+    </section>
 
     <nav class="bottom-nav">
-      <button class="nav-btn active"><span>🏆</span><span>成就</span></button>
-      <button class="nav-btn"><span>📊</span><span>统计</span></button>
-      <button class="nav-btn"><span>⚙️</span><span>设置</span></button>
+      <button class="nav-btn active" data-screen="achievement"><svg class="icon-flat" viewBox="0 0 24 24"><path d="M12 3l2.6 5.3L20 9l-4 3.9.9 5.6L12 16l-4.9 2.5.9-5.6L4 9l5.4-.7z"/></svg><span>成就</span></button>
+      <button class="nav-btn" data-screen="stats"><svg class="icon-flat" viewBox="0 0 24 24"><path d="M4 20V10"/><path d="M10 20V4"/><path d="M16 20v-8"/><path d="M22 20V7"/></svg><span>统计</span></button>
+      <button class="nav-btn" data-screen="settings"><svg class="icon-flat" viewBox="0 0 24 24"><path d="M12 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5h.1a1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg><span>设置</span></button>
     </nav>
   </div>
 
@@ -132,6 +158,16 @@
         bg.style.display = 'none';
         sortBtn.classList.add('active');
       }
+    });
+
+    document.querySelectorAll('.nav-btn').forEach(btn => {
+      btn.onclick = () => {
+        document.querySelectorAll('.nav-btn').forEach(n => n.classList.remove('active'));
+        btn.classList.add('active');
+        const key = btn.dataset.screen;
+        document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+        document.getElementById(`screen-${key}`).classList.add('active');
+      };
     });
   </script>
 </body>

--- a/ui-prototype/index.html
+++ b/ui-prototype/index.html
@@ -24,7 +24,7 @@
       color: var(--text);
       display: flex; justify-content: center; padding: 24px;
     }
-    .phone { width: 390px; min-height: 844px; background: var(--bg); border-radius: 28px; border: 1px solid #2a2a2a; padding: 18px 14px; }
+    .phone { width: 390px; min-height: 844px; background: var(--bg); border-radius: 28px; border: 1px solid #2a2a2a; padding: 18px 14px 88px; position: relative; }
     .title { font-size: 28px; font-weight: 800; margin: 6px 6px 12px; }
     .summary { background: linear-gradient(135deg, #2a2a2a, #262626); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 14px; }
     .summary strong { font-size: 24px; }
@@ -43,6 +43,10 @@
     .item h4 { margin: 0; font-size: 16px; }
     .item p { margin: 4px 0 0; color: var(--muted); font-size: 13px; }
     .badge { font-size: 12px; color: #111; background: var(--accent); border-radius: 999px; padding: 4px 8px; }
+    .bottom-nav { position: absolute; left: 12px; right: 12px; bottom: 14px; height: 58px; border-radius: 16px; border: 1px solid var(--border); background: #242424; display: grid; grid-template-columns: repeat(3,1fr); overflow: hidden; }
+    .nav-btn { border: 0; background: transparent; color: var(--muted); font-size: 13px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap: 4px; cursor:pointer; }
+    .nav-btn.active { color: var(--text); background: #2b2b2b; }
+    .icon-flat { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 1.8; }
     .modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,.45); display:none; align-items: flex-end; justify-content: center; }
     .modal { width: 390px; background: #242424; border-radius: 18px 18px 0 0; border: 1px solid #3a3a3a; padding: 14px; }
     .opt { width: 100%; text-align:left; margin-top: 8px; height: 38px; border-radius: 10px; border: 1px solid var(--border); background: #2a2a2a; color: var(--text); cursor:pointer; }
@@ -63,9 +67,17 @@
         <button id="filterBtn" class="icon-btn">⚲</button>
         <button id="sortBtn" class="icon-btn">↕</button>
       </div>
-      <button id="lockBtn" class="icon-btn">🔓</button>
+      <button id="lockBtn" class="icon-btn" aria-label="锁定">
+        <svg id="lockIcon" class="icon-flat" viewBox="0 0 24 24"><path d="M7 10V7a5 5 0 0 1 10 0v3"/><rect x="5" y="10" width="14" height="10" rx="2"/></svg>
+      </button>
     </div>
     <div class="list" id="list"></div>
+
+    <nav class="bottom-nav">
+      <button class="nav-btn active"><span>🏆</span><span>成就</span></button>
+      <button class="nav-btn"><span>📊</span><span>统计</span></button>
+      <button class="nav-btn"><span>⚙️</span><span>设置</span></button>
+    </nav>
   </div>
 
   <div id="sortModalBg" class="modal-bg">
@@ -105,7 +117,9 @@
     filterBtn.onclick = () => filterBtn.classList.toggle('active');
     lockBtn.onclick = () => {
       lockBtn.classList.toggle('active');
-      lockBtn.textContent = lockBtn.classList.contains('active') ? '🔒' : '🔓';
+      document.getElementById('lockIcon').innerHTML = lockBtn.classList.contains('active')
+        ? '<path d="M7 10V7a5 5 0 0 1 10 0v3"/><rect x="5" y="10" width="14" height="10" rx="2"/>'
+        : '<path d="M7 10V7a5 5 0 0 1 9.5-2"/><path d="M12 13v3"/><rect x="5" y="10" width="14" height="10" rx="2"/>';
     };
     todoBtn.onclick = () => todoBtn.classList.toggle('active');
     bg.onclick = (e) => {

--- a/ui-prototype/index.html
+++ b/ui-prototype/index.html
@@ -41,7 +41,9 @@
     .icon-btn { width: 40px; height: 32px; border-radius: 10px; border: 1px solid var(--border); background: #262626; color: var(--text); cursor: pointer; }
     .icon-btn.active { background: #2f3140; border-color: var(--primary-soft); }
     .list { margin-top: 12px; display: grid; gap: 10px; }
+    .phone.compact .list { gap: 8px; }
     .item { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 12px; display:flex; justify-content: space-between; align-items: center; }
+    .phone.compact .item { padding: 9px 10px; }
     .item.done { opacity: .72; }
     .item.done h4 { text-decoration: line-through; }
     .item h4 { margin: 0; font-size: 16px; }
@@ -50,6 +52,7 @@
     .badge { font-size: 12px; color: #111; background: var(--accent); border-radius: 999px; padding: 4px 8px; }
     .done-btn { width: 24px; height: 24px; border-radius: 7px; border:1px solid var(--border); background:#2b2b2b; color: var(--text); cursor:pointer; }
     .item.done .done-btn { background: #3a315f; border-color: var(--primary-soft); }
+    .done-btn:disabled { opacity: .4; cursor: not-allowed; }
     .bottom-nav { position: absolute; left: 12px; right: 12px; bottom: 14px; height: 58px; border-radius: 16px; border: 1px solid var(--border); background: #242424; display: grid; grid-template-columns: repeat(3,1fr); overflow: hidden; }
     .nav-btn { border: 0; background: transparent; color: var(--muted); font-size: 13px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap: 4px; cursor:pointer; }
     .nav-btn.active { color: var(--text); background: #2b2b2b; }
@@ -68,7 +71,7 @@
         <div>总进度 <strong>142/378</strong></div>
         <div class="progress"><div class="bar"></div></div>
       </div>
-      <div class="search"><input placeholder="搜索成就 / 输入关键词" /></div>
+      <div class="search"><input id="searchInput" placeholder="搜索成就 / 输入关键词" /></div>
       <div class="row">
         <div class="left">
           <button id="todoBtn" class="chip active">仅未完成</button>
@@ -88,19 +91,17 @@
 
     <section id="screen-stats" class="screen">
       <div class="title">统计</div>
-      <div class="summary"><div>总完成率 <strong>37.6%</strong></div><div class="progress"><div class="bar"></div></div></div>
-      <div class="list">
-        <div class="item"><div><h4>2.0 版本</h4><p>完成 31 / 82</p></div><span class="badge">37%</span></div>
-        <div class="item"><div><h4>战斗类</h4><p>完成 48 / 130</p></div><span class="badge">36%</span></div>
-      </div>
+      <div class="summary"><div>总完成率 <strong id="statsRate">0%</strong></div><div class="progress"><div id="statsBar" class="bar"></div></div></div>
+      <div id="statsList" class="list"></div>
     </section>
 
     <section id="screen-settings" class="screen">
       <div class="title">设置</div>
       <div class="list">
-        <div class="item"><div><h4>主题模式</h4><p>深色</p></div></div>
-        <div class="item"><div><h4>紧凑模式</h4><p>已启用</p></div></div>
-        <div class="item"><div><h4>导出进度</h4><p>JSON</p></div></div>
+        <div class="item"><div><h4>紧凑模式</h4><p id="compactLabel">已启用</p></div><button id="compactBtn" class="chip active">切换</button></div>
+        <div class="item"><div><h4>导出进度</h4><p>JSON</p></div><button id="exportBtn" class="chip">导出</button></div>
+        <div class="item"><div><h4>导入进度</h4><p>JSON</p></div><button id="importBtn" class="chip">导入</button><input id="importFile" type="file" accept="application/json" style="display:none"></div>
+        <div class="item"><div><h4>重置进度</h4><p>恢复为初始状态</p></div><button id="resetBtn" class="chip">重置</button></div>
       </div>
     </section>
 
@@ -114,66 +115,148 @@
   <div id="sortModalBg" class="modal-bg">
     <div class="modal">
       <h3 style="margin:0 0 6px;">排序方式</h3>
-      <button class="opt active">版本：新 → 旧</button>
-      <button class="opt">版本：旧 → 新</button>
-      <button class="opt">名称</button>
-      <button class="opt">未完成优先</button>
+      <button class="opt active" data-sort="verDesc">版本：新 → 旧</button>
+      <button class="opt" data-sort="verAsc">版本：旧 → 新</button>
+      <button class="opt" data-sort="name">名称</button>
+      <button class="opt" data-sort="todo">未完成优先</button>
+    </div>
+  </div>
+
+  <div id="filterModalBg" class="modal-bg">
+    <div class="modal">
+      <h3 style="margin:0 0 6px;">筛选版本</h3>
+      <div id="filterOptions"></div>
+      <button id="filterClear" class="opt">清除筛选</button>
     </div>
   </div>
 
   <script>
-    const data = [
-      { title:'今天也要打卡', desc:'每日任务完成 1 次', ver:'2.0', done:false },
-      { title:'喧响测试员', desc:'完成一次高危副本', ver:'1.9', done:false },
-      { title:'完美闪避大师', desc:'10 次极限闪避', ver:'2.0', done:true },
-      { title:'预算控制', desc:'累计获取 100000 丁尼', ver:'1.8', done:false },
-      { title:'收藏家', desc:'解锁 20 条图鉴', ver:'1.7', done:true },
+    const STORAGE_KEY = 'zzz_ui_proto_v1';
+    const seed = [
+      { id:1, title:'今天也要打卡', desc:'每日任务完成 1 次', ver:'2.0', done:false },
+      { id:2, title:'喧响测试员', desc:'完成一次高危副本', ver:'1.9', done:false },
+      { id:3, title:'完美闪避大师', desc:'10 次极限闪避', ver:'2.0', done:true },
+      { id:4, title:'预算控制', desc:'累计获取 100000 丁尼', ver:'1.8', done:false },
+      { id:5, title:'收藏家', desc:'解锁 20 条图鉴', ver:'1.7', done:true },
     ];
+
+    let state = loadState() || {
+      data: seed,
+      onlyTodo: true,
+      search: '',
+      sortMode: 'verDesc',
+      selectedVersions: [],
+      locked: false,
+      compact: true
+    };
+
     const list = document.getElementById('list');
+    const sortBtn = document.getElementById('sortBtn');
+    const filterBtn = document.getElementById('filterBtn');
+    const lockBtn = document.getElementById('lockBtn');
+    const todoBtn = document.getElementById('todoBtn');
+    const searchInput = document.getElementById('searchInput');
+    const sortBg = document.getElementById('sortModalBg');
+    const filterBg = document.getElementById('filterModalBg');
+
+    function loadState() {
+      try { return JSON.parse(localStorage.getItem(STORAGE_KEY)); } catch { return null; }
+    }
+    function saveState() { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }
+
+    function getFilteredSorted() {
+      let arr = [...state.data];
+      if (state.onlyTodo) arr = arr.filter(x => !x.done);
+      if (state.search.trim()) {
+        const q = state.search.trim().toLowerCase();
+        arr = arr.filter(x => x.title.toLowerCase().includes(q) || x.desc.toLowerCase().includes(q));
+      }
+      if (state.selectedVersions.length) arr = arr.filter(x => state.selectedVersions.includes(x.ver));
+      if (state.sortMode === 'verDesc') arr.sort((a,b) => Number(b.ver)-Number(a.ver));
+      if (state.sortMode === 'verAsc') arr.sort((a,b) => Number(a.ver)-Number(b.ver));
+      if (state.sortMode === 'name') arr.sort((a,b) => a.title.localeCompare(b.title,'zh-CN'));
+      if (state.sortMode === 'todo') arr.sort((a,b) => Number(a.done)-Number(b.done));
+      return arr;
+    }
 
     function renderList() {
-      list.innerHTML = '';
-      data.forEach((it, idx) => {
+      const arr = getFilteredSorted();
+      list.innerHTML = arr.length ? '' : '<div class="item"><div><h4>暂无结果</h4><p>试试清空筛选或搜索关键词</p></div></div>';
+      arr.forEach((it) => {
         const el = document.createElement('div');
         el.className = `item ${it.done ? 'done' : ''}`;
         el.innerHTML = `
           <div><h4>${it.title}</h4><p>${it.desc}</p></div>
           <div class="right-pack">
             <span class="badge">v${it.ver}</span>
-            <button class="done-btn" data-idx="${idx}" title="标记完成">${it.done ? '✓' : ''}</button>
+            <button class="done-btn" data-id="${it.id}" title="标记完成" ${state.locked ? 'disabled' : ''}>${it.done ? '✓' : ''}</button>
           </div>`;
         list.appendChild(el);
       });
     }
 
-    renderList();
+    function renderStats() {
+      const total = state.data.length;
+      const done = state.data.filter(x => x.done).length;
+      const rate = total ? Math.round(done*100/total) : 0;
+      document.getElementById('statsRate').textContent = `${rate}%`;
+      document.getElementById('statsBar').style.width = `${rate}%`;
 
-    const sortBtn = document.getElementById('sortBtn');
-    const filterBtn = document.getElementById('filterBtn');
-    const lockBtn = document.getElementById('lockBtn');
-    const todoBtn = document.getElementById('todoBtn');
-    const bg = document.getElementById('sortModalBg');
+      const byVer = Object.fromEntries([...new Set(state.data.map(x=>x.ver))].map(v => [v, state.data.filter(x=>x.ver===v)]));
+      const stats = Object.entries(byVer).map(([v,arr]) => {
+        const d = arr.filter(x=>x.done).length;
+        return `<div class="item"><div><h4>${v} 版本</h4><p>完成 ${d} / ${arr.length}</p></div><span class="badge">${Math.round(d*100/arr.length)}%</span></div>`;
+      }).join('');
+      document.getElementById('statsList').innerHTML = stats;
+    }
 
-    sortBtn.onclick = () => { bg.style.display = 'flex'; sortBtn.classList.add('active'); };
-    filterBtn.onclick = () => filterBtn.classList.toggle('active');
-    lockBtn.onclick = () => {
-      lockBtn.classList.toggle('active');
-      document.getElementById('lockIcon').innerHTML = lockBtn.classList.contains('active')
+    function renderFilters() {
+      const versions = [...new Set(state.data.map(x=>x.ver))].sort((a,b)=>Number(b)-Number(a));
+      const box = document.getElementById('filterOptions');
+      box.innerHTML = versions.map(v => `<button class="opt ${state.selectedVersions.includes(v)?'active':''}" data-ver="${v}">版本 ${v}</button>`).join('');
+      filterBtn.classList.toggle('active', state.selectedVersions.length>0);
+    }
+
+    function renderAll() {
+      todoBtn.classList.toggle('active', state.onlyTodo);
+      searchInput.value = state.search;
+      document.querySelector('.phone').classList.toggle('compact', state.compact);
+      document.getElementById('compactLabel').textContent = state.compact ? '已启用' : '已关闭';
+      document.getElementById('compactBtn').classList.toggle('active', state.compact);
+      lockBtn.classList.toggle('active', state.locked);
+      document.getElementById('lockIcon').innerHTML = state.locked
         ? '<path d="M7 10V7a5 5 0 0 1 10 0v3"/><rect x="5" y="10" width="14" height="10" rx="2"/>'
         : '<path d="M7 10V7a5 5 0 0 1 9.5-2"/><path d="M12 13v3"/><rect x="5" y="10" width="14" height="10" rx="2"/>';
-    };
-    todoBtn.onclick = () => todoBtn.classList.toggle('active');
-    bg.onclick = (e) => {
-      if (e.target === bg) { bg.style.display = 'none'; sortBtn.classList.remove('active'); }
-    };
-    document.querySelectorAll('.opt').forEach(btn => {
-      btn.onclick = () => {
-        document.querySelectorAll('.opt').forEach(o => o.classList.remove('active'));
-        btn.classList.add('active');
-        bg.style.display = 'none';
-        sortBtn.classList.add('active');
-      }
+      document.querySelectorAll('.opt[data-sort]').forEach(o => o.classList.toggle('active', o.dataset.sort===state.sortMode));
+      sortBtn.classList.toggle('active', state.sortMode!=='verDesc');
+      renderFilters();
+      renderList();
+      renderStats();
+      saveState();
+    }
+
+    sortBtn.onclick = () => sortBg.style.display = 'flex';
+    filterBtn.onclick = () => filterBg.style.display = 'flex';
+    lockBtn.onclick = () => { state.locked = !state.locked; renderAll(); };
+    todoBtn.onclick = () => { state.onlyTodo = !state.onlyTodo; renderAll(); };
+    searchInput.oninput = (e) => { state.search = e.target.value; renderAll(); };
+
+    sortBg.onclick = (e) => { if (e.target === sortBg) sortBg.style.display = 'none'; };
+    filterBg.onclick = (e) => { if (e.target === filterBg) filterBg.style.display = 'none'; };
+
+    document.querySelectorAll('.opt[data-sort]').forEach(btn => {
+      btn.onclick = () => { state.sortMode = btn.dataset.sort; sortBg.style.display = 'none'; renderAll(); };
     });
+
+    document.getElementById('filterOptions').addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-ver]'); if (!btn) return;
+      const v = btn.dataset.ver;
+      state.selectedVersions = state.selectedVersions.includes(v)
+        ? state.selectedVersions.filter(x => x!==v)
+        : [...state.selectedVersions, v];
+      renderAll();
+    });
+    document.getElementById('filterClear').onclick = () => { state.selectedVersions = []; renderAll(); };
 
     document.querySelectorAll('.nav-btn').forEach(btn => {
       btn.onclick = () => {
@@ -186,12 +269,31 @@
     });
 
     list.addEventListener('click', (e) => {
-      const btn = e.target.closest('.done-btn');
-      if (!btn) return;
-      const idx = Number(btn.dataset.idx);
-      data[idx].done = !data[idx].done;
-      renderList();
+      const btn = e.target.closest('.done-btn'); if (!btn || state.locked) return;
+      const id = Number(btn.dataset.id);
+      const item = state.data.find(x => x.id===id);
+      if (item) item.done = !item.done;
+      renderAll();
     });
+
+    document.getElementById('compactBtn').onclick = () => { state.compact = !state.compact; renderAll(); };
+    document.getElementById('exportBtn').onclick = () => {
+      const blob = new Blob([JSON.stringify(state.data, null, 2)], {type:'application/json'});
+      const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = 'zzz-progress.json'; a.click();
+      URL.revokeObjectURL(a.href);
+    };
+    document.getElementById('importBtn').onclick = () => document.getElementById('importFile').click();
+    document.getElementById('importFile').onchange = async (e) => {
+      const file = e.target.files[0]; if (!file) return;
+      try {
+        const arr = JSON.parse(await file.text());
+        if (Array.isArray(arr)) state.data = state.data.map(x => ({...x, done: !!arr.find(y => y.id===x.id)?.done}));
+        renderAll();
+      } catch { alert('导入失败：JSON 格式不正确'); }
+    };
+    document.getElementById('resetBtn').onclick = () => { if (confirm('确认重置进度？')) { state.data = seed.map(x=>({...x})); renderAll(); } };
+
+    renderAll();
   </script>
 </body>
 </html>

--- a/ui-prototype/index.html
+++ b/ui-prototype/index.html
@@ -124,20 +124,23 @@
 
   <div id="filterModalBg" class="modal-bg">
     <div class="modal">
-      <h3 style="margin:0 0 6px;">筛选版本</h3>
-      <div id="filterOptions"></div>
-      <button id="filterClear" class="opt">清除筛选</button>
+      <h3 style="margin:0 0 6px;">筛选</h3>
+      <p style="margin:8px 0 4px;color:var(--muted);font-size:13px;">版本</p>
+      <div id="filterVersionOptions"></div>
+      <p style="margin:12px 0 4px;color:var(--muted);font-size:13px;">分类</p>
+      <div id="filterCategoryOptions"></div>
+      <button id="filterClear" class="opt">清除全部筛选</button>
     </div>
   </div>
 
   <script>
     const STORAGE_KEY = 'zzz_ui_proto_v1';
     const seed = [
-      { id:1, title:'今天也要打卡', desc:'每日任务完成 1 次', ver:'2.0', done:false },
-      { id:2, title:'喧响测试员', desc:'完成一次高危副本', ver:'1.9', done:false },
-      { id:3, title:'完美闪避大师', desc:'10 次极限闪避', ver:'2.0', done:true },
-      { id:4, title:'预算控制', desc:'累计获取 100000 丁尼', ver:'1.8', done:false },
-      { id:5, title:'收藏家', desc:'解锁 20 条图鉴', ver:'1.7', done:true },
+      { id:1, title:'今天也要打卡', desc:'每日任务完成 1 次', ver:'2.0', cat:'日常', done:false },
+      { id:2, title:'喧响测试员', desc:'完成一次高危副本', ver:'1.9', cat:'战斗', done:false },
+      { id:3, title:'完美闪避大师', desc:'10 次极限闪避', ver:'2.0', cat:'战斗', done:true },
+      { id:4, title:'预算控制', desc:'累计获取 100000 丁尼', ver:'1.8', cat:'成长', done:false },
+      { id:5, title:'收藏家', desc:'解锁 20 条图鉴', ver:'1.7', cat:'探索', done:true },
     ];
 
     let state = loadState() || {
@@ -146,9 +149,11 @@
       search: '',
       sortMode: 'verDesc',
       selectedVersions: [],
+      selectedCategories: [],
       locked: false,
       compact: true
     };
+    state.selectedCategories = state.selectedCategories || [];
 
     const list = document.getElementById('list');
     const sortBtn = document.getElementById('sortBtn');
@@ -172,6 +177,7 @@
         arr = arr.filter(x => x.title.toLowerCase().includes(q) || x.desc.toLowerCase().includes(q));
       }
       if (state.selectedVersions.length) arr = arr.filter(x => state.selectedVersions.includes(x.ver));
+      if (state.selectedCategories.length) arr = arr.filter(x => state.selectedCategories.includes(x.cat));
       if (state.sortMode === 'verDesc') arr.sort((a,b) => Number(b.ver)-Number(a.ver));
       if (state.sortMode === 'verAsc') arr.sort((a,b) => Number(a.ver)-Number(b.ver));
       if (state.sortMode === 'name') arr.sort((a,b) => a.title.localeCompare(b.title,'zh-CN'));
@@ -188,6 +194,7 @@
         el.innerHTML = `
           <div><h4>${it.title}</h4><p>${it.desc}</p></div>
           <div class="right-pack">
+            <span class="badge">${it.cat}</span>
             <span class="badge">v${it.ver}</span>
             <button class="done-btn" data-id="${it.id}" title="标记完成" ${state.locked ? 'disabled' : ''}>${it.done ? '✓' : ''}</button>
           </div>`;
@@ -212,9 +219,12 @@
 
     function renderFilters() {
       const versions = [...new Set(state.data.map(x=>x.ver))].sort((a,b)=>Number(b)-Number(a));
-      const box = document.getElementById('filterOptions');
-      box.innerHTML = versions.map(v => `<button class="opt ${state.selectedVersions.includes(v)?'active':''}" data-ver="${v}">版本 ${v}</button>`).join('');
-      filterBtn.classList.toggle('active', state.selectedVersions.length>0);
+      const categories = [...new Set(state.data.map(x=>x.cat))];
+      const vBox = document.getElementById('filterVersionOptions');
+      const cBox = document.getElementById('filterCategoryOptions');
+      vBox.innerHTML = versions.map(v => `<button class="opt ${state.selectedVersions.includes(v)?'active':''}" data-ver="${v}">版本 ${v}</button>`).join('');
+      cBox.innerHTML = categories.map(c => `<button class="opt ${state.selectedCategories.includes(c)?'active':''}" data-cat="${c}">${c}</button>`).join('');
+      filterBtn.classList.toggle('active', state.selectedVersions.length>0 || state.selectedCategories.length>0);
     }
 
     function renderAll() {
@@ -248,7 +258,7 @@
       btn.onclick = () => { state.sortMode = btn.dataset.sort; sortBg.style.display = 'none'; renderAll(); };
     });
 
-    document.getElementById('filterOptions').addEventListener('click', (e) => {
+    document.getElementById('filterVersionOptions').addEventListener('click', (e) => {
       const btn = e.target.closest('[data-ver]'); if (!btn) return;
       const v = btn.dataset.ver;
       state.selectedVersions = state.selectedVersions.includes(v)
@@ -256,7 +266,15 @@
         : [...state.selectedVersions, v];
       renderAll();
     });
-    document.getElementById('filterClear').onclick = () => { state.selectedVersions = []; renderAll(); };
+    document.getElementById('filterCategoryOptions').addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-cat]'); if (!btn) return;
+      const c = btn.dataset.cat;
+      state.selectedCategories = state.selectedCategories.includes(c)
+        ? state.selectedCategories.filter(x => x!==c)
+        : [...state.selectedCategories, c];
+      renderAll();
+    });
+    document.getElementById('filterClear').onclick = () => { state.selectedVersions = []; state.selectedCategories = []; renderAll(); };
 
     document.querySelectorAll('.nav-btn').forEach(btn => {
       btn.onclick = () => {

--- a/ui-prototype/index.html
+++ b/ui-prototype/index.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ZZZ Achievement UI Prototype</title>
+  <style>
+    :root {
+      --bg: #1e1e1e;
+      --card: #232323;
+      --primary: #896cfe;
+      --primary-soft: #b3a0ff;
+      --accent: #e2f163;
+      --text: #f2f2f2;
+      --muted: #a6a6a6;
+      --border: #3a3a3a;
+      --radius-lg: 18px;
+      --radius-md: 12px;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; font-family: Inter, -apple-system, Segoe UI, Roboto, sans-serif;
+      background: radial-gradient(1200px 800px at 70% -200px, #3e2a7c, var(--bg));
+      color: var(--text);
+      display: flex; justify-content: center; padding: 24px;
+    }
+    .phone { width: 390px; min-height: 844px; background: var(--bg); border-radius: 28px; border: 1px solid #2a2a2a; padding: 18px 14px; }
+    .title { font-size: 28px; font-weight: 800; margin: 6px 6px 12px; }
+    .summary { background: linear-gradient(135deg, #2a2a2a, #262626); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 14px; }
+    .summary strong { font-size: 24px; }
+    .progress { height: 8px; border-radius: 999px; background: #333; margin-top: 10px; overflow: hidden; }
+    .bar { width: 38%; height: 100%; background: linear-gradient(90deg, var(--accent), #b4f64e); }
+    .search { margin-top: 12px; display: flex; gap: 8px; }
+    input { flex: 1; background: #262626; border: 1px solid var(--border); color: var(--text); border-radius: 14px; padding: 12px; }
+    .row { margin-top: 10px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+    .left { display:flex; gap: 8px; align-items: center; }
+    .chip { height: 32px; border-radius: 10px; border: 1px solid var(--border); padding: 0 12px; background: #262626; color: var(--text); cursor: pointer; }
+    .chip.active { background: #2f3140; border-color: var(--primary-soft); }
+    .icon-btn { width: 40px; height: 32px; border-radius: 10px; border: 1px solid var(--border); background: #262626; color: var(--text); cursor: pointer; }
+    .icon-btn.active { background: #2f3140; border-color: var(--primary-soft); }
+    .list { margin-top: 12px; display: grid; gap: 10px; }
+    .item { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 12px; display:flex; justify-content: space-between; align-items: center; }
+    .item h4 { margin: 0; font-size: 16px; }
+    .item p { margin: 4px 0 0; color: var(--muted); font-size: 13px; }
+    .badge { font-size: 12px; color: #111; background: var(--accent); border-radius: 999px; padding: 4px 8px; }
+    .modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,.45); display:none; align-items: flex-end; justify-content: center; }
+    .modal { width: 390px; background: #242424; border-radius: 18px 18px 0 0; border: 1px solid #3a3a3a; padding: 14px; }
+    .opt { width: 100%; text-align:left; margin-top: 8px; height: 38px; border-radius: 10px; border: 1px solid var(--border); background: #2a2a2a; color: var(--text); cursor:pointer; }
+    .opt.active { border-color: var(--primary); background: #32295a; }
+  </style>
+</head>
+<body>
+  <div class="phone">
+    <div class="title">成就</div>
+    <div class="summary">
+      <div>总进度 <strong>142/378</strong></div>
+      <div class="progress"><div class="bar"></div></div>
+    </div>
+    <div class="search"><input placeholder="搜索成就 / 输入关键词" /></div>
+    <div class="row">
+      <div class="left">
+        <button id="todoBtn" class="chip active">仅未完成</button>
+        <button id="filterBtn" class="icon-btn">⚲</button>
+        <button id="sortBtn" class="icon-btn">↕</button>
+      </div>
+      <button id="lockBtn" class="icon-btn">🔓</button>
+    </div>
+    <div class="list" id="list"></div>
+  </div>
+
+  <div id="sortModalBg" class="modal-bg">
+    <div class="modal">
+      <h3 style="margin:0 0 6px;">排序方式</h3>
+      <button class="opt active">版本：新 → 旧</button>
+      <button class="opt">版本：旧 → 新</button>
+      <button class="opt">名称</button>
+      <button class="opt">未完成优先</button>
+    </div>
+  </div>
+
+  <script>
+    const data = [
+      ['今天也要打卡', '每日任务完成 1 次', '2.0'],
+      ['喧响测试员', '完成一次高危副本', '1.9'],
+      ['完美闪避大师', '10 次极限闪避', '2.0'],
+      ['预算控制', '累计获取 100000 丁尼', '1.8'],
+      ['收藏家', '解锁 20 条图鉴', '1.7'],
+    ];
+    const list = document.getElementById('list');
+    data.forEach(([t,d,v], i) => {
+      const done = i % 2 === 0;
+      const el = document.createElement('div');
+      el.className = 'item';
+      el.innerHTML = `<div><h4>${t}</h4><p>${d}</p></div><span class="badge">v${v}</span>`;
+      list.appendChild(el);
+    });
+
+    const sortBtn = document.getElementById('sortBtn');
+    const filterBtn = document.getElementById('filterBtn');
+    const lockBtn = document.getElementById('lockBtn');
+    const todoBtn = document.getElementById('todoBtn');
+    const bg = document.getElementById('sortModalBg');
+
+    sortBtn.onclick = () => { bg.style.display = 'flex'; sortBtn.classList.add('active'); };
+    filterBtn.onclick = () => filterBtn.classList.toggle('active');
+    lockBtn.onclick = () => {
+      lockBtn.classList.toggle('active');
+      lockBtn.textContent = lockBtn.classList.contains('active') ? '🔒' : '🔓';
+    };
+    todoBtn.onclick = () => todoBtn.classList.toggle('active');
+    bg.onclick = (e) => {
+      if (e.target === bg) { bg.style.display = 'none'; sortBtn.classList.remove('active'); }
+    };
+    document.querySelectorAll('.opt').forEach(btn => {
+      btn.onclick = () => {
+        document.querySelectorAll('.opt').forEach(o => o.classList.remove('active'));
+        btn.classList.add('active');
+        bg.style.display = 'none';
+        sortBtn.classList.add('active');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 变更内容
- 完成新版 UI 布局与样式落地（成就/统计/设置 + 底部导航）
- 接入筛选与排序：版本/分类多选筛选、排序方式切换
- 完成搜索、仅未完成过滤、勾选状态锁定切换
- 完成统计页展示与设置页导入/导出/重置入口
- 完成状态迁移与排序集成收尾（含状态字段兼容）

## 验证
- 本地构建通过：`..\\gradle-8.7\\bin\\gradle.bat -p . assembleDebug`

## 备注
- 本次为 UI 重构功能交付，后续可继续补充更细粒度交互微调与视觉 polish。